### PR TITLE
Renamed reserved class names to {$classname}Type

### DIFF
--- a/lib/Filterus/Filter.php
+++ b/lib/Filterus/Filter.php
@@ -5,17 +5,17 @@ namespace Filterus;
 abstract class Filter {
 
     protected static $filters = array(
-        'alnum'  => 'Filterus\Filters\Alnum',
-        'array'  => 'Filterus\Filters\Arrays',
-        'bool'   => 'Filterus\Filters\Boolean',
+        'alnum'  => 'Filterus\Filters\AlnumType',
+        'array'  => 'Filterus\Filters\ArrayType',
+        'bool'   => 'Filterus\Filters\BooleanType',
         'email'  => 'Filterus\Filters\Email',
-        'float'  => 'Filterus\Filters\Float',
-        'int'    => 'Filterus\Filters\Int',
+        'float'  => 'Filterus\Filters\FloatType',
+        'int'    => 'Filterus\Filters\IntType',
         'ip'     => 'Filterus\Filters\IP',
-        'object' => 'Filterus\Filters\Object',
-        'raw'    => 'Filterus\Filters\Raw',
+        'object' => 'Filterus\Filters\ObjectType',
+        'raw'    => 'Filterus\Filters\RawType',
         'regex'  => 'Filterus\Filters\Regex',
-        'string' => 'Filterus\Filters\String',
+        'string' => 'Filterus\Filters\StringType',
         'url'    => 'Filterus\Filters\URL',
     );
 
@@ -27,11 +27,11 @@ abstract class Filter {
         if ($values) {
             $options['values'] = $values;
         }
-        return new Filters\Arrays($options);
+        return new Filters\ArrayType($options);
     }
 
     public static function map($filters) {
-        return new Filters\Map(array('filters' => $filters));
+        return new Filters\MapType(array('filters' => $filters));
     }
 
     public static function chain() {
@@ -47,7 +47,7 @@ abstract class Filter {
     public static function factory($filter) {
         if ($filter instanceof self) {
             return $filter;
-        } 
+        }
         list ($filterName, $options) = static::parseFilter($filter);
         if (!isset(self::$filters[$filterName])) {
             throw new \InvalidArgumentException('Invalid Filter Specified: ' . $filter);
@@ -55,14 +55,14 @@ abstract class Filter {
         $class = self::$filters[$filterName];
         return new $class($options);
     }
-    
+
     public static function registerFilter($name, $class) {
         if (!is_subclass_of($class, __CLASS__)) {
             throw new \InvalidArgumentException("Class name must be an instance of Filter");
         }
         self::$filters[strtolower($name)] = $class;
     }
-    
+
 
     protected $defaultOptions = array();
 

--- a/lib/Filterus/Filters/AlnumType.php
+++ b/lib/Filterus/Filters/AlnumType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Alnum extends Regex {
-    
+class AlnumType extends Regex {
+
     protected $defaultOptions = array(
         'min' => 0,
         'max' => PHP_INT_MAX,

--- a/lib/Filterus/Filters/ArrayType.php
+++ b/lib/Filterus/Filters/ArrayType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Arrays extends \Filterus\Filter {
-    
+class ArrayType extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'min' => 0,
         'max' => PHP_INT_MAX,

--- a/lib/Filterus/Filters/BooleanType.php
+++ b/lib/Filterus/Filters/BooleanType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Boolean extends \Filterus\Filter {
-    
+class BooleanType extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'default' => null,
     );

--- a/lib/Filterus/Filters/FloatType.php
+++ b/lib/Filterus/Filters/FloatType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Float extends \Filterus\Filter {
-    
+class FloatType extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'min' => null,
         'max' => null,

--- a/lib/Filterus/Filters/IntType.php
+++ b/lib/Filterus/Filters/IntType.php
@@ -4,8 +4,8 @@ namespace Filterus\Filters;
 
 defined('PHP_INT_MIN') or define('PHP_INT_MIN', ~PHP_INT_MAX);
 
-class Int extends \Filterus\Filter {
-    
+class IntType extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'min' => PHP_INT_MIN,
         'max' => PHP_INT_MAX,

--- a/lib/Filterus/Filters/MapType.php
+++ b/lib/Filterus/Filters/MapType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Map extends \Filterus\Filter {
-    
+class MapType extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'filters' => array(),
     );

--- a/lib/Filterus/Filters/ObjectType.php
+++ b/lib/Filterus/Filters/ObjectType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Object extends \Filterus\Filter {
-    
+class ObjectType extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'class' => '',
     );

--- a/lib/Filterus/Filters/RawType.php
+++ b/lib/Filterus/Filters/RawType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Raw extends \Filterus\Filter {
-    
+class RawType extends \Filterus\Filter {
+
     public function filter($var) {
         return $var;
     }

--- a/lib/Filterus/Filters/Regex.php
+++ b/lib/Filterus/Filters/Regex.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Regex extends String {
-    
+class Regex extends StringType {
+
     protected $defaultOptions = array(
         'min' => 0,
         'max' => PHP_INT_MAX,

--- a/lib/Filterus/Filters/StringType.php
+++ b/lib/Filterus/Filters/StringType.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class String extends \Filterus\Filter {
-    
+class StringType extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'min' => 0,
         'max' => PHP_INT_MAX,

--- a/test/Filterus/FilterTest.php
+++ b/test/Filterus/FilterTest.php
@@ -5,7 +5,7 @@ namespace Filterus;
 class FilterTest extends \PHPUnit_Framework_TestCase {
 
     public function testOptions() {
-        $filter = new Filters\Raw;
+        $filter = new Filters\RawType;
         $filter->setOptions(array(1, 2));
         $this->assertEquals(array(1, 2), $filter->getOptions());
         $filter->setOption('foo', 'bar');
@@ -16,15 +16,15 @@ class FilterTest extends \PHPUnit_Framework_TestCase {
 
     public function testFactory() {
         $raw = Filter::factory('raw');
-        $this->assertTrue($raw instanceof Filters\Raw);
+        $this->assertTrue($raw instanceof Filters\RawType);
     }
 
     public function testFactoryParsing() {
         $raw = Filter::factory('raw,foo:bar');
-        $this->assertTrue($raw instanceof Filters\Raw);
+        $this->assertTrue($raw instanceof Filters\RawType);
         $this->assertEquals(array('foo' => 'bar'), $raw->getOptions());
         $raw = Filter::factory('raw,foo:bar,');
-        $this->assertTrue($raw instanceof Filters\Raw);
+        $this->assertTrue($raw instanceof Filters\RawType);
         $this->assertEquals(array('foo' => 'bar'), $raw->getOptions());
     }
 
@@ -42,9 +42,9 @@ class FilterTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testFactoryRegister() {
-        Filter::registerFilter('gibberish', 'Filterus\Filters\Raw');
+        Filter::registerFilter('gibberish', 'Filterus\Filters\RawType');
         $expect = Filter::factory('gibberish');
-        $this->assertTrue($expect instanceof Filters\Raw);
+        $this->assertTrue($expect instanceof Filters\RawType);
     }
 
     /**
@@ -69,30 +69,30 @@ class FilterTest extends \PHPUnit_Framework_TestCase {
     public function testMap() {
         $mapArray = array('a' => 'int');
         $map = Filter::map($mapArray);
-        $this->assertTrue($map instanceof Filters\Map);
+        $this->assertTrue($map instanceof Filters\MapType);
         $this->assertEquals(array('filters' => $mapArray), $map->getOptions());
     }
 
     public function testArrays() {
         $array = Filter::arrays();
-        $this->assertTrue($array instanceof Filters\Arrays);
+        $this->assertTrue($array instanceof Filters\ArrayType);
     }
 
     public function testArraysOptions() {
         $array = Filter::arrays('foo:bar');
-        $this->assertTrue($array instanceof Filters\Arrays);
+        $this->assertTrue($array instanceof Filters\ArrayType);
         $this->assertEquals(array('foo' => 'bar', 'min' => 0, 'max' => PHP_INT_MAX, 'keys' => null, 'values' => null), $array->getOptions());
     }
 
     public function testArraysKeys() {
         $array = Filter::arrays('', 'int');
-        $this->assertTrue($array instanceof Filters\Arrays);
+        $this->assertTrue($array instanceof Filters\ArrayType);
         $this->assertEquals(array('min' => 0, 'max' => PHP_INT_MAX, 'keys' => 'int', 'values' => null), $array->getOptions());
     }
 
     public function testArraysValues() {
         $array = Filter::arrays('', '', 'int');
-        $this->assertTrue($array instanceof Filters\Arrays);
+        $this->assertTrue($array instanceof Filters\ArrayType);
         $this->assertEquals(array('min' => 0, 'max' => PHP_INT_MAX, 'keys' => null, 'values' => 'int'), $array->getOptions());
     }
 

--- a/test/Filterus/Filters/AlnumTest.php
+++ b/test/Filterus/Filters/AlnumTest.php
@@ -31,7 +31,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Alnum($options);
+        $int = new AlnumType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }

--- a/test/Filterus/Filters/ArraysTest.php
+++ b/test/Filterus/Filters/ArraysTest.php
@@ -24,7 +24,7 @@ class ArraysTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Arrays($options);
+        $int = new ArrayType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }

--- a/test/Filterus/Filters/BooleanTest.php
+++ b/test/Filterus/Filters/BooleanTest.php
@@ -18,7 +18,7 @@ class BooleanTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Boolean($options);
+        $int = new BooleanType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }

--- a/test/Filterus/Filters/FloatTest.php
+++ b/test/Filterus/Filters/FloatTest.php
@@ -28,7 +28,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Float($options);
+        $int = new FloatType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }

--- a/test/Filterus/Filters/IntTest.php
+++ b/test/Filterus/Filters/IntTest.php
@@ -28,7 +28,7 @@ class IntTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Int($options);
+        $int = new IntType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }

--- a/test/Filterus/Filters/MapTest.php
+++ b/test/Filterus/Filters/MapTest.php
@@ -32,7 +32,7 @@ class MapTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Map($options);
+        $int = new MapType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }

--- a/test/Filterus/Filters/ObjectTest.php
+++ b/test/Filterus/Filters/ObjectTest.php
@@ -22,7 +22,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Object($options);
+        $int = new ObjectType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }

--- a/test/Filterus/Filters/RawTest.php
+++ b/test/Filterus/Filters/RawTest.php
@@ -16,7 +16,7 @@ class RawTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($raw) {
-        $int = new Raw(array());
+        $int = new RawType(array());
         $this->assertEquals($raw, $int->filter($raw));
         $this->assertEquals(true, $int->validate($raw));
     }

--- a/test/Filterus/Filters/StringTest.php
+++ b/test/Filterus/Filters/StringTest.php
@@ -30,7 +30,7 @@ class StringTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new String($options);
+        $int = new StringType($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }


### PR DESCRIPTION
In PHP7 some classnames are reserved and requires a change. 
This is discussed in 
https://github.com/Respect/Validation/issues/362

Their suggestion is to use the prefix Type on the classes.