### PR TITLE
refactor "Filters\Object" to "Filters\Objects"

### DIFF
--- a/lib/Filterus/Filter.php
+++ b/lib/Filterus/Filter.php
@@ -12,7 +12,7 @@ abstract class Filter {
         'float'  => 'Filterus\Filters\Floats',
         'int'    => 'Filterus\Filters\Ints',
         'ip'     => 'Filterus\Filters\IP',
-        'object' => 'Filterus\Filters\Object',
+        'object' => 'Filterus\Filters\Objects',
         'raw'    => 'Filterus\Filters\Raw',
         'regex'  => 'Filterus\Filters\Regex',
         'string' => 'Filterus\Filters\Strings',
@@ -48,7 +48,7 @@ abstract class Filter {
     public static function factory($filter) {
         if ($filter instanceof self) {
             return $filter;
-        } 
+        }
         list ($filterName, $options) = static::parseFilter($filter);
         if (!isset(self::$filters[$filterName])) {
             throw new \InvalidArgumentException('Invalid Filter Specified: ' . $filter);
@@ -56,14 +56,14 @@ abstract class Filter {
         $class = self::$filters[$filterName];
         return new $class($options);
     }
-    
+
     public static function registerFilter($name, $class) {
         if (!is_subclass_of($class, __CLASS__)) {
             throw new \InvalidArgumentException("Class name must be an instance of Filter");
         }
         self::$filters[strtolower($name)] = $class;
     }
-    
+
 
     protected $defaultOptions = array();
 

--- a/lib/Filterus/Filters/Objects.php
+++ b/lib/Filterus/Filters/Objects.php
@@ -2,8 +2,8 @@
 
 namespace Filterus\Filters;
 
-class Object extends \Filterus\Filter {
-    
+class Objects extends \Filterus\Filter {
+
     protected $defaultOptions = array(
         'class' => '',
     );

--- a/test/Filterus/Filters/ObjectTest.php
+++ b/test/Filterus/Filters/ObjectTest.php
@@ -22,7 +22,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTestFilter
      */
     public function testFilter($options, $raw, $filtered, $valid) {
-        $int = new Object($options);
+        $int = new Objects($options);
         $this->assertEquals($filtered, $int->filter($raw));
         $this->assertEquals($valid, $int->validate($raw));
     }


### PR DESCRIPTION
Starting from php7.2 "Object" became a reserved word.